### PR TITLE
Add ROM info to Hardware Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Hardware
 - [BL602/604 Datasheet](mirrored/BL602_BL604_DS_Datasheet.pdf)
   (34 pages): Includes pinout, memory map, and general peripheral descriptions
   but no detailed functional specification or register listings. Sipeed, a board
-  vendor that plans to use the BL602, `claims <https://twitter.com/SipeedIO/status/1321658609990725633>`_
+  vendor that plans to use the BL602, [claims](https://twitter.com/SipeedIO/status/1321658609990725633)
   that full register documentation will be available sometime in November 2020.
 - [soc602_reg.svd][1]: Contains a seemingly-complete register listing, with
   names but no descriptions, for the BL602.


### PR DESCRIPTION
pine64/bl_iot_sdk#46, take two. Also fixed an RST-style link in the README that I missed in #4.