### PR TITLE
[Wifi Phy] Add some info about wifi

### DIFF
--- a/reverse_engineered/hardware_notes.md
+++ b/reverse_engineered/hardware_notes.md
@@ -82,6 +82,9 @@ unified table. I make no guarantees to the accuracy of this table.
 | `0x4000_F800` | `0x4000_FFFF` |  `aon` (analog domain control?)            |
 | `0x4001_0000` | `0x4001_0FFF` |  Deep sleep retention RAM                  |
 | `0x4202_0000` | `0x4203_BFFF` |  Wireless RAM (datasheet disagrees on base)|
+| `0x44c0_0000` | `0x44c?_????` |  `wifi phy` (identified from `phy_init`) (has many wifi related modules including `acg`)      |
+| `0x54c0_a000` | `0x54c0_????` |  `agc` ucode (identified from `phy_init`)  |
+
 
 (Peripherals in *`italics`* are present in the SVD but not the datasheet.)
 


### PR DESCRIPTION
Extracted from `phy_init`. 
```
        23014204 b7  07  c0  44    lui        a5,0x44c00
        23014208 80  43           c.lw       s0,0x0 (a5=>MDM_NXVERSION )
```

The begin of this mem region is likely to be `MDM_NXVERSION` and `0x44c0000` is the memory region for wifi phy.
But in the following code it says `(((uint32_t)rxnssmax << 4) & ~((uint32_t)0x00000070)) == 0"`, so it can also be some data packed together. 

```
  puVar6 = agcmem;
  puVar4 = (uint32_t *)&DAT_54c0a000;
  do {
    uVar3 = *puVar6;
    puVar5 = puVar4 + 1;
    puVar6 = puVar6 + 1;
    *puVar4 = uVar3;
    puVar4 = puVar5;
  } while (puVar5 != (uint32_t *)0x54c0a800);
``` 
Here it moves AGC ucode to AGC memory, so `0x54c0_a000` should be the begining of AGC ucode region.