### PR TITLE
clean up rst

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,19 @@
 BL602 Documentation
 ===================
 
-The documentation can be found [online][1] at [pine64.github.io/bl602-docs][1]
+This documentation can be found [online][1] at [pine64.github.io/bl602-docs][1].
 
 Building The Documentation
 --------------------------
-To build the documentation your self:
+To build the documentation yourself:
 ```bash
 $ cd src
-$ python -m pip install --requirement=requirements.txt
+$ python -m pip install -r requirements.txt
 $ cd en   # cd zh to build documentation in chinese
-$ make html
+$ make html  # on Windows, set SPHINXBUILD="python -m sphinx" for this command
 ```
-After successfully building the documentation navigate to `docs`.
-There ought to be an `index.html` file. Open it with firefox/your browser of choice.
-
+The documentation will be built inside the `docs` folder. To view it, open `docs/index.html`
+in your browser of choice.
 
 Hardware
 --------

--- a/src/en/Developer_Environment/Developer_Environment.rst
+++ b/src/en/Developer_Environment/Developer_Environment.rst
@@ -1,5 +1,5 @@
 Developer Environment
-========================
+=====================
 
 This directory explains the usage of tools such as the compiler, downloader and debugger.
 

--- a/src/en/Developer_Environment/freedom_studio/freedom_studio.rst
+++ b/src/en/Developer_Environment/freedom_studio/freedom_studio.rst
@@ -1,19 +1,19 @@
 Freedom Studio
-================
+==============
 
 This document describes the use of Freedom Studio.
 
 Importing a project
---------
+-------------------
 
 - First of all, start ``Freedom Studio``, open ``File > import`` on the toolbar and select ``Existing Projects into Workspace`` option under ``General`` menu to import projects.
 
 
 .. figure:: imgs/image01.png
-   :alt: 
+   :alt:
 
 .. figure:: imgs/image02.png
-   :alt: 
+   :alt:
 
 Debug
 -----
@@ -35,7 +35,7 @@ Debug
    :alt:
 
 -   You can add and delete breakpoints by double-clicking on the leftmost orange bar of the ``code`` window.
- 
+
 .. figure:: imgs/image08.png
    :alt:
 

--- a/src/en/Quickstart_Guide/Linux/Quickstart_Linux_ubuntu.rst
+++ b/src/en/Quickstart_Guide/Linux/Quickstart_Linux_ubuntu.rst
@@ -20,8 +20,8 @@ This picture shows the front of the module. Connect the pins in position 1, 2 an
 
 .. figure:: imgs/image1110.png
    :alt:
-   
-This picture shows the back of the module. Connect the header pin `ʻIO8`` to ``LOW``.
+
+This picture shows the back of the module. Connect the header pin ``IO8`` to ``LOW``.
 
 .. figure:: imgs/image127.png
    :alt:


### PR DESCRIPTION
- Replaced unintentional unicode `ʻ` with backtick
- Cleaned up RST header lengths
- Minor grammatical tweaks
- Instructions for building on Windows