### PR TITLE
Run doc build for PRs

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -2,6 +2,8 @@ name: Build Documentation
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
     
 jobs:
   build:
@@ -23,6 +25,7 @@ jobs:
           make html
           
       - name: deploy to github pages
+        if: ${{ github.event_name == 'push' }}
         uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Builds the docs for PRs -- hopefully catch issues building docs before they get merged to main. GitHub Actions does not give builds run by PRs from forks access to secrets.

Actions run for a PR targeting main (deploy step skipped): https://github.com/nightlark/bl602-docs/runs/1440113069?check_suite_focus=true
Actions run for a commit to main (deploy step run): https://github.com/nightlark/bl602-docs/runs/1440115706?check_suite_focus=true