### PR TITLE
Tweak Linux Start Guide minor copy re: genromap

### DIFF
--- a/src/en/Quickstart_Guide/Linux/Quickstart_Linux_ubuntu.rst
+++ b/src/en/Quickstart_Guide/Linux/Quickstart_Linux_ubuntu.rst
@@ -29,7 +29,7 @@ This picture shows the back of the module. Connect the header pin ``IO8`` to ``L
 Compiling and Flashing
 ----------------------
 
--  Enter your project directory, and compile using the binary \ ``./genromap``
+-  Enter your project directory, and compile using the executable \ ``./genromap``
 
    .. figure:: imgs/image48.png
       :alt:


### PR DESCRIPTION
Unless I'm missing something, the tools called `genromap` are scripts that wrap `make` ([e.g.](https://github.com/pine64/bl_iot_sdk/blob/c00a0980dcc562083b8ea5713abb1ac569b826e7/customer_app/sdk_app_cli/genromap)). I know this is splitting hairs, but they're not binaries.

The [Windows version of the guide](https://github.com/pine64/bl602-docs/blame/7de02d919f9991e27efa7a3711b955ee92b9090a/src/en/Quickstart_Guide/Windows/Quickstart_Windows_msys.rst#L67) calls this a "command," so, that's another option.

Thanks!