### PR TITLE
Add peripheral details about checksum engine

### DIFF
--- a/hardware_notes/README.md
+++ b/hardware_notes/README.md
@@ -74,7 +74,7 @@ None of the information in this table has been verified (yet)
 | `0x4000_A400` | `0x4000_A4FF` |  `pwm` (Pulse Width Modulation #1-#6)                                                    | [PWM](registers/pwm.md)             |
 | `0x4000_A500` | `0x4000_A5FF` |  `timer` (Timer #1 and #2)                                                               | [TIMER](registers/timer.md)         |
 | `0x4000_A600` | `0x4000_A6FF` |  `ir` (infrared remote accelerator)                                                      | [IR](registers/ir.md)               |
-| `0x4000_A000` | `0x4000_AFFF` |  *`cks`* (???, conflicts with others)                                                    | [CKS](registers/cks.md)             |
+| `0x4000_A700` | `0x4000_A7FF` |  *`cks`* (checksum engine)                                                               | [CKS](registers/cks.md)             |
 | `0x4000_B000` | `0x4000_B6FF` |  `sf_ctrl` (serial flash control)                                                        | [SF_CTRL](registers/sf_ctrl.md)     |
 | `0x4000_B700` | `0x4000_BFFF` |  `sf_ctrl_buf` (serial flash data buffer)                                                |                                     |
 | `0x4000_C000` | `0x4000_CFFF` |  `dma` (Direct Memory Access engine)                                                     | [DMA](registers/dma.md)             |

--- a/hardware_notes/registers/cks.md
+++ b/hardware_notes/registers/cks.md
@@ -1,15 +1,19 @@
-# Peripheral: cks
+# Peripheral: CKS
 
-- Register base address: 0x4000A000
+- Register base address: 0x4000A700
 
 ## Registers
 
-| Register offset | Register size | Field offset | Field size | Name             | Direction  | Description |
-| --------------- | ------------- | ------------ | ---------- | ---------------- | ---------- | ----------- |
-| 0x0000          | 32            |              |            | cks_config       | read-write | cks_config. |
-|                 |               | 0x0000       | 1          | cr_cks_clr       |            |             |
-|                 |               | 0x0001       | 1          | cr_cks_byte_swap |            |             |
-| 0x0004          | 32            |              |            | data_in          | read-write | data_in.    |
-|                 |               | 0x0000       | 8          | data_in          |            |             |
-| 0x0008          | 32            |              |            | cks_out          | read-write | cks_out.    |
-|                 |               | 0x0000       | 16         | cks_out          |            |             |
+| Register offset | Register size | Field offset | Field size | Name             | Direction  | Description                                      |
+| --------------- | ------------- | ------------ | ---------- | ---------------- | ---------- | -----------                                      |
+| 0x0000          | 32            |              |            | cks_config       | read-write | CKS control                                      |
+|                 |               | 0x0000       | 1          | cr_cks_clr       |            | Write `1` to clear state                         |
+|                 |               | 0x0001       | 1          | cr_cks_byte_swap |            | Endianness (`0`: little endian, `1`: big endian) |
+| 0x0004          | 32            |              |            | data_in          | read-write |                                                  |
+|                 |               | 0x0000       | 8          | data_in          |            | Single byte input                                |
+| 0x0008          | 32            |              |            | cks_out          | read-write |                                                  |
+|                 |               | 0x0000       | 16         | cks_out          |            | 16-bit output checksum                           |
+
+## Sources
+
+* [bl_cks.c](https://github.com/bouffalolab/bl_iot_sdk/blob/3bc544d9f3243d411cad249a49769980b9ac6b76/components/hal_drv/bl602_hal/bl_cks.c)


### PR DESCRIPTION
I'm not sure whether it's more appropriate to call this a checksum accelerator.