### PR TITLE
improving hello world example & fix Readme dead links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ in your browser of choice.
 Hardware
 --------
 - [Official Documents](https://github.com/bouffalolab/bl_docs): Includes detailed core and peripheral documentation
-- [BL602/604 Datasheet](mirrored/Bouffalo%20Lab%20BL602_BL604_DS_en_Combo_1.2.pdf)
-  (34 pages): Includes pinout, memory map, and general peripheral descriptions
+- [BL602/604 Datasheet](main/mirrored/BL602_BL604_DS_1.4_en.pdf)
+  (32 pages): Includes pinout, memory map, and general peripheral descriptions
   but no detailed functional specification or register listings.
-- [BL602/604 Reference Manual](mirrored/Bouffalo%20Lab%20BL602_Reference_Manual_en_1.1.pdf)
-  (209 pages): Includes register map, clock tree and other information about implementing BL602/BL604
+- [BL602/604 Reference Manual](mirrored/BL602_BL604_RM_1.2_en.pdf)
+  (195 pages): Includes register map, clock tree and other information about implementing BL602/BL604
 - [soc602_reg.svd][2]: Contains a seemingly-complete register listing, with
   names but no descriptions, for the BL602.
 - [Hardware Notes](hardware_notes): Additional information

--- a/src/en/Examples/helloworld/helloworld.rst
+++ b/src/en/Examples/helloworld/helloworld.rst
@@ -10,16 +10,22 @@ This project explains how to start up the board and print simple logging message
 
 Code Examples
 -------------
-::
+.. code-block:: c
 
-    bl_uart_init(0, 16, 7, 255, 255, 2 * 1000 * 1000);
-    helloworld();
+    bl_uart_init(0, 16, 7, 255, 255, 230400);
+    printf("Hello World!\r\n");
 
-Here we configure the baud rate to 2000000bps. Run the example, and you should see ``start`` ， ``helloworld`` ， ``end`` printed to the serial console.
+According to ``bl_uart_init``'s prototype:
+
+.. code-block:: c
+
+    int bl_uart_init(uint8_t id, uint8_t tx_pin, uint8_t rx_pin, uint8_t cts_pin, uint8_t rts_pin, uint32_t baudrate)
+
+The ``id`` must be set to 0, other values won't work. Pine64's Nutcracker uses pin 16 for ``tx_pin`` and pin 7 for ``rx_pin``. The baud is set to 230400bps, it can be any value between 1200 (very slow) and 2000000 (very fast). The purpose of ``cts_pin`` and ``rts_pin`` remains unknown, they are not really used anywhere in the lib's code, and any value (between 0 and 255) seems to to work. Though official examples set both of them to 255.
+
+Run the example, and you should see ``Hello World!`` printed to the serial console (screen, minicom, gtkterm...) like this:
 
 .. code-block:: bash
 
-    [helloworld]   start
-    [helloworld]   helloworld
-    [helloworld]   end
+    Hello World!
 


### PR DESCRIPTION
This is a little improvement of the Hello World example.
I replaced the call of the `helloworld()` by a `printf()`, I think it's more intuitive.

I also added a prototype of the `bl_uart_init()` function to make things clearer and explained a little more its parameters.

I finally took the liberty to change the baud rate, because with some test I figured out that if the baud rate is too high, some bugged characters are printed. I chose 230 400 because it's a multiple of the standard 9600 and seems to me to be a good compromise, it is fast enough and has no bugged character.